### PR TITLE
Fixing the PNG data processing issue that occurs sometimes in Firefox.

### DIFF
--- a/life/build.hxml
+++ b/life/build.hxml
@@ -3,6 +3,7 @@
 -cp ../Muun/src
 -cp ../Std/src
 -L hgsl
+-L format
 -D analyzer-optimize
 -D js-es=6
 --main Main

--- a/life/src/Main.hx
+++ b/life/src/Main.hx
@@ -70,17 +70,7 @@ class Main extends App {
 		speedTextG = speedText.getGraphics();
 		speedTextTexture = g.loadBitmap(speedText);
 
-		ImageLoader.loadImages(["graph.png", "anim.png", "loc.png"], imgs -> {
-			final graphImg = imgs[0];
-			final animImg = imgs[1];
-			final locImg = imgs[2];
-			graphImg.loadPixels();
-			animImg.loadPixels();
-			locImg.loadPixels();
-			final decoder = new Decoder();
-			decoder.decodeGraph(cast graphImg.pixels);
-			decoder.decodeAnim(cast animImg.pixels);
-			decoder.decodeLocation(cast locImg.pixels);
+		function onDecoded(decoder: Decoder) {
 			graph = decoder.graph;
 			frames = decoder.frames;
 			sampler = new Sampler(graph, frames);
@@ -92,6 +82,36 @@ class Main extends App {
 			final cover = Browser.document.getElementById("cover");
 			cover.parentElement.removeChild(cover);
 			pot.start();
+		}
+
+		// Old load - relied on accurate CanvasRenderingContext2D::drawImage
+		// Fails in some browsers with anti-fingerprinting features enabled
+
+		/*
+		ImageLoader.loadImages(["graph.png", "anim.png", "loc.png"], imgs -> {
+			final graphImg = imgs[0];
+			final animImg = imgs[1];
+			final locImg = imgs[2];
+			graphImg.loadPixels();
+			animImg.loadPixels();
+			locImg.loadPixels();
+
+			final decoder = new Decoder();
+			decoder.decodeGraph(cast graphImg.pixels);
+			decoder.decodeAnim(cast animImg.pixels);
+			decoder.decodeLocation(cast locImg.pixels);
+			onDecoded(decoder);
+		});
+		*/
+
+		// Fixed load - relies on fetch() and the 'format' haxe library for png decoding
+
+		PNGLoader.loadImages(["graph.png", "anim.png", "loc.png"], pixelData -> {
+			final decoder = new Decoder();
+			decoder.decodeGraph(pixelData[0]);
+			decoder.decodeAnim(pixelData[1]);
+			decoder.decodeLocation(pixelData[2]);
+			onDecoded(decoder);
 		});
 	}
 

--- a/life/src/PNGLoader.hx
+++ b/life/src/PNGLoader.hx
@@ -1,0 +1,34 @@
+import haxe.io.Bytes;
+import haxe.io.BytesInput;
+import js.Browser;
+import js.Syntax;
+import js.lib.Promise;
+import format.png.Reader;
+import format.png.Tools;
+
+/**
+ * ...
+ */
+
+class PNGLoader {
+	public static function loadImages(sources:Array<String>, onFinished:(pixelData:Array<Array<Int>>) -> Void, onError:Void -> Void = null):Void {
+		Promise.all([
+			for (source in sources)
+				Browser.window.fetch(source)
+					.then(response -> response.arrayBuffer())
+					.then(buf ->
+						Tools.extract32(
+							new Reader(
+								new BytesInput(Bytes.ofData(buf))
+							).read()
+						)
+					)
+		])
+		.then(pngs -> {
+			onFinished([for (png in pngs) Syntax.code("Array.from(new Uint32Array({0}.b.buffer))", png) ]);
+		})
+		.catchError(error -> {
+			if (onError != null) onError();
+		});
+	}
+}


### PR DESCRIPTION
Hello @saharan!

Life Universe has recently [garnered interest on Hacker News.](https://news.ycombinator.com/item?id=39799755) Well done and well deserved! I love this project and your techniques, and I'm happy to see my old language of choice Haxe play a role in someone's extraordinary project.

There seem to be anti-fingerprinting features in recent browsers that can cause the result of `CanvasRenderingContext2D::drawImage` to be inaccurate, which has made the project inoperable in some visitors' browsers. This PR contains a basic fix that uses the `haxe.format` library to decode the PNGs loaded with the `fetch` API, circumventing the whole fingerprinting problem.

My goal was to fix this quickly in the short term, but in the long term, you may wish to use a different file format than PNG to represent this data.

This contribution requires no attribution whatsoever. It's a pleasure to meet you!

-Rezmason